### PR TITLE
Reset best-performers accumulator per horizon set

### DIFF
--- a/revision/analysis/run-selection-ensemble.R
+++ b/revision/analysis/run-selection-ensemble.R
@@ -20,10 +20,12 @@ su_cols <- c("model", "forecast_date", "quantile", "horizon",
 
 
 
-best_performers_data <- NULL
-k <- 1
-
 for(horizons in horizon_sets){
+
+  #reset the accumulator for each horizon set, otherwise the _allhor output
+  #inherits the rows written during the 2-week run
+  best_performers_data <- NULL
+  k <- 1
 
   #appendix results
   if (length(horizons) == 4){


### PR DESCRIPTION
This PR closes #11.

## Summary
The accumulator `best_performers_data` and index `k` were initialised once before the `for(horizons in horizon_sets)` loop and never reset, so the second iteration (`c(1,2,3,4)`, `_allhor`) `rbindlist`ed in the rows written during the first (`c(1,2)`) iteration. This doubled the rows of `best_performers_incl_mods_allhor.csv` and left many `(forecast_date, location, target_type)` groups with more than `nmod=3` models, corrupting the weighted-ensemble panel of the all-horizon appendix tileplot.

## Change
- `revision/analysis/run-selection-ensemble.R`: reset `best_performers_data <- NULL; k <- 1` at the top of each `horizon_sets` iteration.

Note: committed outputs under `revision/output/selection-ensemble/` and the affected appendix figure will need regenerating.