### PR TITLE
Make nmod-specific selection an if/else if/else chain

### DIFF
--- a/scripts/04_run-selection-ensemble.R
+++ b/scripts/04_run-selection-ensemble.R
@@ -84,8 +84,7 @@ for(horizons in horizon_sets){
 
       lwr <- 1
       upr <- 6 #was 7 before!
-    }
-    if(nmod == 10){
+    } else if(nmod == 10){
       #exclude loc-target combs if they don't have enough models
       #here: only include DE&PL Deaths and Cases
       bp_data <- hub_data |>


### PR DESCRIPTION
This PR closes #12.

## Summary
The `nmod == 8` and `nmod == 10` special cases were two independent `if` statements. For `nmod == 8`, the first block set the restricted `bp_data`, but the following `if(nmod == 10){...} else {...}` then ran its `else`, overwriting `bp_data`/`lwr`/`upr` back to the full unrestricted set, so the nmod=8 restriction never took effect. Intermediate `best_performers_*_nmod8.csv` / weights CSVs were mislabelled; the final scores were only saved because `selection-ensemble-exclude-instances.csv` is anti-joined downstream.

## Change
- `scripts/04_run-selection-ensemble.R`: join the second condition into the first with `else if(nmod == 10)`, giving a proper `if / else if / else` chain.

Note: intermediate nmod=8 outputs will need regenerating.