### PR TITLE
Exclude baseline from component-model count

### DIFF
--- a/scripts/07_produce-plots.R
+++ b/scripts/07_produce-plots.R
@@ -189,7 +189,7 @@ num_mods <- function(
     length()
 
   combdat <- fcdat |>
-    filter(!model == "EuroCOVIDhub-ensemble") |>
+    filter(!model %in% c("EuroCOVIDhub-ensemble", "EuroCOVIDhub-baseline")) |>
     filter(forecast_date >= as.IDate(start_date)) |>
     filter(forecast_date <= as.IDate(end_date)) |>
     select(model, forecast_date, location, target_type) |>


### PR DESCRIPTION
This PR closes #14.

## Summary
`num_mods()` filtered out `EuroCOVIDhub-ensemble` (which does not exist as a model string in `fcdat.parquet`, so a no-op) but never excluded `EuroCOVIDhub-baseline`, which is present in ~97% of instances. The count plotted as "Number of Component Models" in `model-availability.pdf` therefore over-counted by 1 almost everywhere, treating the naive baseline as a genuine component model.

## Change
- `scripts/07_produce-plots.R`: exclude both `EuroCOVIDhub-ensemble` and `EuroCOVIDhub-baseline` in `num_mods()`.

Note: `model-availability.pdf` will need regenerating.