### PR TITLE
Derive location with substr instead of broken regex

### DIFF
--- a/scripts/06_run-ensemble-diversity.R
+++ b/scripts/06_run-ensemble-diversity.R
@@ -92,8 +92,7 @@ k_max <- filter(ensemble_scores, homog) |>
 ensemble_scores <- filter(ensemble_scores,
                           target %in% k_max$target) |>
   # clean variables
-  mutate(location = str_remove_all(target, "Deaths_k[:digit:]"),
-         location = str_remove_all(target, "Cases_k[:digit:]"),
+  mutate(location = substr(target, 1, 2),
          location = fct_infreq(location),
          horizon = ordered(horizon, levels = c(1,2),
                            labels = c("1 week", "2 week")),


### PR DESCRIPTION
This PR closes #13.

## Summary
The `location` column was built with `str_remove_all(target, "Deaths_k[:digit:]")` / `"Cases_k[:digit:]"`. Two bugs: the second `location =` discarded the first (later assignment in a single `mutate()` wins), and `[:digit:]` is a bracket expression matching one literal char from `{:,d,i,g,t}`, not a digit. Result: e.g. `"DEDeaths_k5"` stayed `"DEDeaths_k5"` and `"DECases_k12"` was left uncleaned. This corrupted `location` in `enscomb_scores_with_classification.parquet` (masked downstream because `07_produce-plots.R` recomputes `substr(target, 1, 2)`).

## Change
- `scripts/06_run-ensemble-diversity.R`: set `location = substr(target, 1, 2)` (matching how script 07 derives it).

Note: `enscomb_scores_with_classification.parquet` will need regenerating.