### PR TITLE
Restrict diversity analysis to k with feasible homogeneous ensembles

### DIFF
--- a/scripts/06_run-ensemble-diversity.R
+++ b/scripts/06_run-ensemble-diversity.R
@@ -84,13 +84,20 @@ ensemble_scores <- left_join(scores, ensemble_mix,
   filter(!is.na(classification))
 
 
-# restrict to k < possible single-type ensembles
-k_max <- filter(ensemble_scores, homog) |>
-  group_by(target, horizon) |>
-  summarise(k = max(k))
+# restrict to k <= the largest k at which a single-type (homogeneous) ensemble
+# is possible for that location-target. target encodes k (loc_kN), so strip it
+# before taking the max, otherwise every (target, horizon) group holds a single k.
+k_max <- ensemble_scores |>
+  filter(homog) |>
+  mutate(loctarget = sub("_k[0-9]+$", "", target)) |>
+  group_by(loctarget, horizon) |>
+  summarise(k_max = max(k), .groups = "drop")
 
-ensemble_scores <- filter(ensemble_scores,
-                          target %in% k_max$target) |>
+ensemble_scores <- ensemble_scores |>
+  mutate(loctarget = sub("_k[0-9]+$", "", target)) |>
+  left_join(k_max, by = c("loctarget", "horizon")) |>
+  filter(!is.na(k_max), k <= k_max) |>
+  select(-loctarget, -k_max) |>
   # clean variables
   mutate(location = str_remove_all(target, "Deaths_k[:digit:]"),
          location = str_remove_all(target, "Cases_k[:digit:]"),

--- a/scripts/07_produce-plots.R
+++ b/scripts/07_produce-plots.R
@@ -703,10 +703,6 @@ ensemble_scores <- arrow::read_parquet(here("output", "ensemble-diversity", "ens
 model_class <- arrow::read_parquet(here("output", "ensemble-diversity", "component_model_classification.parquet"))
 models <- arrow::read_parquet(here("output", "ensemble-diversity", "enscomb_with_classification.parquet"))
 
-k_max <- filter(ensemble_scores, homog == "Homogeneous") |>
-  group_by(target, horizon) |>
-  summarise(k = max(k))
-
 # Count number of ensembles by homogeneous/heterogeneous type
 num_ensembles <- ensemble_scores |>
   select(target, homog, ensid, k) |>


### PR DESCRIPTION
This PR closes #15.

## ⚠️ Changes results — needs author confirmation before merge
This alters which ensembles enter the ensemble-diversity analysis, so `ensemble-diversity.pdf` and `enscomb_scores_with_classification.parquet` will change. Please confirm the intended restriction before regenerating.

## Summary
The `k_max` filter was meant to "restrict to k < possible single-type ensembles", but `target` already encodes k (`loc_kN`), so `group_by(target, horizon) |> summarise(k = max(k))` put each k in its own singleton group and `target %in% k_max$target` applied no k-restriction at all. The current diversity analysis therefore includes all k, including k above the point where homogeneous (single-type) ensembles are still feasible.

## Change
- `scripts/06_run-ensemble-diversity.R`: strip the `_kN` suffix to get the location-target, compute the largest k with a homogeneous ensemble per `(location-target, horizon)`, and keep only ensembles with `k <= k_max`.
- `scripts/07_produce-plots.R`: remove the identical `k_max` block, which was dead code (computed, never used).

If the intent was in fact to apply **no** restriction, the fix is instead to delete the `k_max` block in script 06 — happy to switch to that.