### PR TITLE
Use avg_points_data argument in best_performers_boxplot

### DIFF
--- a/R/functions-selection-ensemble.R
+++ b/R/functions-selection-ensemble.R
@@ -663,7 +663,7 @@ best_performers_boxplot <- function(best_performers_data,
 
   if(!is.null(avg_points_data)){
     plot <- plot +
-      geom_point(data = all_evals_avg, aes(x = factor(nmod),
+      geom_point(data = avg_points_data, aes(x = factor(nmod),
                                            y = rel_score),
                  shape = 18, color = "black", size = 2)
   }


### PR DESCRIPTION
This PR closes #16.

## Summary
`best_performers_boxplot()` null-checked its `avg_points_data` parameter but then plotted the free/global variable `all_evals_avg` instead. It only produced correct output because callers assign a global `all_evals_avg` immediately before each call; any reordering or reuse with a different argument would silently plot the wrong averages.

## Change
- `R/functions-selection-ensemble.R`: `geom_point(data = avg_points_data, ...)` inside the `!is.null(avg_points_data)` branch.

No output changes expected (the current global happens to equal the argument at every call site).