### PR TITLE
Write period_cats to data/auxiliary where the pipeline reads it

### DIFF
--- a/scripts/00_download-data/make-period-cat.R
+++ b/scripts/00_download-data/make-period-cat.R
@@ -24,4 +24,5 @@ period_cat_dt <- lapply(seq_along(period_cat),
          forecast_date = as.Date(forecast_date))
 
 
-data.table::fwrite(period_cat_dt, here::here("data", "period_cats.csv"))
+dir.create(here::here("data", "auxiliary"), recursive = TRUE, showWarnings = FALSE)
+data.table::fwrite(period_cat_dt, here::here("data", "auxiliary", "period_cats.csv"))


### PR DESCRIPTION
This PR closes #18.

## Summary
`make-period-cat.R` wrote to `data/period_cats.csv`, but `01_load-data.R` reads `data/auxiliary/period_cats.csv`. Re-running the script produced a stray file and left the one the pipeline consumes stale/untouched, so `period_cats` could not be regenerated.

## Change
- `scripts/00_download-data/make-period-cat.R`: write to `data/auxiliary/period_cats.csv` (with a `dir.create` so the folder exists on a fresh clone).