### PR TITLE
Pin model-classification download and load readr

### DIFF
--- a/scripts/00_download-data/get-classification.R
+++ b/scripts/00_download-data/get-classification.R
@@ -1,9 +1,14 @@
 # Load packages
 library(data.table)
 library(here)
+library(readr)
+
+# Pinned to a specific commit for reproducibility (was the floating `main` branch).
+class_commit <- "55b8c1e9e9758a54945354620c4635519f6a7a45"
+model_class <- read_csv(paste0(
+  "https://raw.githubusercontent.com/epiforecasts/eval-by-method/",
+  class_commit, "/data/model-classification.csv"))
 
 
-model_class <- read_csv("https://raw.githubusercontent.com/epiforecasts/eval-by-method/main/data/model-classification.csv")
-
-
+dir.create(here("data", "raw-downloads"), recursive = TRUE, showWarnings = FALSE)
 fwrite(model_class, here("data", "raw-downloads", "model-classifications.csv"))


### PR DESCRIPTION
This PR closes #19.

## Summary
`get-classification.R` called `read_csv()` without loading `readr` (so a clean session errored with "could not find function") and fetched from the floating `main` branch of `epiforecasts/eval-by-method` (a moving target, contradicting the README claim of a pinned source).

## Change
- `scripts/00_download-data/get-classification.R`: add `library(readr)`, pin the download to commit `55b8c1e9e9758a54945354620c4635519f6a7a45`, and `dir.create` the output folder.

I verified the pinned commit reproduces the committed `data/raw-downloads/model-classifications.csv` exactly (identical model list and classifications; the only textual difference is `NA` vs empty cells, which is just the `read_csv` -> `fwrite` round-trip representation of missing values).