### PR TITLE
Use specs date window and preserve rows in period_cat join

### DIFF
--- a/scripts/01_load-data.R
+++ b/scripts/01_load-data.R
@@ -38,8 +38,8 @@ combdat <- fcdat |>
                                    week_start = getOption("lubridate.week.start", 1)) #round down to Saturday
   ) |>
   filter(!model == "EuroCOVIDhub-ensemble") |>
-  filter(forecast_date >= as.Date("2021-03-11")) |> #before: 2021-03-20
-  filter(forecast_date <= as.Date("2023-03-11")) |>
+  filter(forecast_date >= as.Date(specs$start_date)) |>
+  filter(forecast_date <= as.Date(specs$end_date)) |>
   DT(prediction<0, prediction := 0) |>
   mutate(forecast_date = as.IDate(forecast_date)) |>
   merge_forecasts_with_truth(truth) |>
@@ -55,7 +55,7 @@ combdat <- fcdat |>
                 "quantile", "prediction", "true_value",
                 "prediction_pop", "true_value_pop",
                 "anomaly")) |>
-  DT(period_cats, on = c("forecast_date"))
+  DT(period_cats, on = "forecast_date", period_cat := i.period_cat)
 
 dir.create(here("data", "processed"), recursive = TRUE, showWarnings = FALSE)
 arrow::write_parquet(combdat, here("data", "processed", "fcdat.parquet"))


### PR DESCRIPTION
This PR closes #21.

## Summary
Two issues in `01_load-data.R`:
1. The forecast-date window was hardcoded to `2021-03-11 .. 2023-03-11`, but `specs$end_date` is `2022-03-11` (a year earlier). `specs` was already sourced but not used for these filters, so `fcdat.parquet` retained ~1 extra year of out-of-scope data and the literal was a drift risk.
2. The `period_cat` join `combdat[period_cats, on = "forecast_date"]` was a plain (right-style) join: any `combdat` row whose `forecast_date` was absent from `period_cats` (which only reaches 2023-02-27) would be silently dropped.

## Changes
- Use `specs$start_date` / `specs$end_date` for the date filters.
- Make the `period_cat` join an update-join (`period_cat := i.period_cat`) so every forecast row is preserved.

Downstream scripts already re-filter to the `specs` window, so analysis results are unchanged; `data/processed/fcdat.parquet` will need regenerating (it becomes the `specs` window instead of running to 2023).