### PR TITLE
Analyse all-countries data in revision missingness/availability

### DIFF
--- a/revision/analysis/missingness.R
+++ b/revision/analysis/missingness.R
@@ -7,7 +7,7 @@ library(ggplot2)
 
 DT <- `[`
 
-fcdat <- read_parquet(here("data", "processed", "fcdat.parquet"))
+fcdat <- read_parquet(here("revision", "data", "fcdat_allcountries_filtered.parquet"))
 
 #scoredat <- fcdat |>
 #  DT(, .SD, .SDcols = c("model", "location", "target_type", "forecast_date",
@@ -16,7 +16,7 @@ fcdat <- read_parquet(here("data", "processed", "fcdat.parquet"))
 #                       quantile_level = "quantile") |>
 #  score()
 
-scoredat <- fread(here("data", "processed", "component-model-scores.csv"))
+scoredat <- fread(here("revision", "data", "component-model-scores.csv"))
 
 percdat <- scoredat |>
   DT(, q_wis := (frank(wis, ties.method = "average") - 1) / (.N - 1),

--- a/revision/individual_availability.R
+++ b/revision/individual_availability.R
@@ -3,7 +3,7 @@ library(tidyr)
 library(here)
 library(dplyr)
 
-fcdat <- arrow::read_parquet(here("data", "processed", "fcdat.parquet"))
+fcdat <- arrow::read_parquet(here("revision", "data", "fcdat_allcountries_filtered.parquet"))
 
 # Create complete grid and mark availability
 plot_data <- fcdat |>


### PR DESCRIPTION
This PR closes #22.

## ⚠️ Scope change — please confirm intent
This switches which dataset the revision missingness/availability analyses use, so `missingness.pdf`, `availability_plot.pdf` and the reported Wilcoxon test will change. Please confirm this is the intended scope before regenerating.

## Summary
`revision/analysis/missingness.R` and `revision/individual_availability.R` read `data/processed/fcdat.parquet`, which is the original **5-country** main-paper dataset (`CZ, FR, GB, PL, DE`). The rest of the revision analyses the **~20 other** countries via `revision/data/fcdat_allcountries_filtered.parquet` (and `revision/analysis/plot.R` in the same directory already reads that file). So these two scripts describe a country set with zero overlap with the all-countries analysis they accompany.

## Changes
- `revision/analysis/missingness.R`: read `revision/data/fcdat_allcountries_filtered.parquet` and `revision/data/component-model-scores.csv` (both all-countries) instead of the 5-country `data/processed/` files.
- `revision/individual_availability.R`: read the all-countries parquet.

(Separately, `individual_availability.R` still writes its PDF to the repo root — left unchanged here to keep this PR focused.)