### PR TITLE
Fill in DESCRIPTION metadata and reconcile R version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,17 +1,46 @@
 Package: eurohub-prt
-Title: What the Package Does (One Line, Title Case)
+Title: Ensemble Size and Composition in Combined COVID-19 Forecasts
 Version: 0.0.0.9000
-Authors@R: 
-    person("First", "Last", , "first.last@example.com", role = c("aut", "cre"),
-           comment = c(ORCID = "YOUR-ORCID-ID"))
-Description: What the package does (one paragraph).
-License: `use_mit_license()`, `use_gpl3_license()` or friends to pick a
-    license
+Authors@R: c(
+    person("Friederike", "Becker", role = c("aut", "cre")),
+    person("Katharine", "Sherratt", role = "aut"),
+    person("Nikos I.", "Bosse", role = "aut"),
+    person("Sebastian", "Funk", role = "aut",
+           comment = c(ORCID = "0000-0002-2842-3406")))
+Description: Analysis code for Becker et al., "The influence of ensemble size
+    and composition on the performance of combined real-time COVID-19
+    forecasts", using data from the European COVID-19 Forecast Hub. This is a
+    research compendium rather than an installable package; exact package
+    versions are pinned in renv.lock.
+License: TODO: choose a license (e.g. use_mit_license()) and add a LICENSE file
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
-Suggests: 
+Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
-Imports: 
-    data.table
+Imports:
+    arrow,
+    colorspace,
+    data.table,
+    dplyr,
+    forcats,
+    ggplot2,
+    gh,
+    glue,
+    here,
+    isotone,
+    kableExtra,
+    knitr,
+    lubridate,
+    memoise,
+    MetBrewer,
+    patchwork,
+    purrr,
+    readr,
+    scoringutils,
+    spatstat.geom,
+    stringr,
+    tidyr
+Remotes:
+    reichlab/covidHubUtils

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ eurohub-prt/
 
 ### 1. Prerequisites
 
-- R (≥ 4.1)
+- R (≥ 4.5; `renv.lock` was built with R 4.5.3)
 - The [`renv`](https://rstudio.github.io/renv/) package
 
 ### 2. Clone the repository


### PR DESCRIPTION
This PR closes #23 (partly — see remaining author decisions below).

## Summary
Metadata/packaging cleanup for the research compendium.

## Changes
- `DESCRIPTION`: real Title and Description; author list (Becker, Sherratt, Bosse, Funk); declare the actual dependencies in `Imports` (was only `data.table`) with `covidHubUtils` under `Remotes`.
- `README.md`: state R (≥ 4.5) to match `renv.lock` (was ≥ 4.1 while the lockfile pins R 4.5.3).

## ⚠️ Needs author input (not done here, to avoid guessing)
- **License**: `DESCRIPTION` `License:` is left as a `TODO` and there is still no `LICENSE` file (the README links to one). Please pick a license (e.g. MIT) and add it; the README link will then resolve.
- **Author emails / ORCIDs**: only Funk`s ORCID is filled in; please add the others` emails/ORCIDs (the `cre` author normally needs an email).

`renv::restore()` already installs the correct pinned versions, so this DESCRIPTION change is about honest metadata rather than a functional dependency fix.